### PR TITLE
Adde basic python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
+venv/
+lib/__pycache__/
 beautifyJson.py
 beautifiedMatchIDdata

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-league of legend int detector 👅👅👅👅👅👅👅👅👅👅👅👅👅
+# league of legend int detector 👅👅👅👅👅👅👅👅👅👅👅👅👅
+
+## Setup Environment
+
+On Unix (linux, macos) systems
+Run `source setup.sh`
+
+On Windows Command Prompt
+Run `.\setup.bat`
+
+On Windows Powershell
+Run `.\setup.ps1`

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ Run `.\setup.bat`
 
 On Windows Powershell
 Run `.\setup.ps1`
+
+## Start
+Run `python main.py`

--- a/lib/api.py
+++ b/lib/api.py
@@ -1,0 +1,7 @@
+import requests
+
+# API Actions here
+
+def do_something():
+    print("Doing something")
+    return True

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from lib.api import do_something
+
+print("Hello World")
+
+do_something()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,18 @@
+@echo off
+
+:: Check if running in PowerShell
+if defined PSModulePath (
+    echo This script cannot be run from PowerShell. Use setup.ps1
+    exit /b
+)
+
+:: Create a virtual environment
+python -m venv venv
+
+:: Activate the virtual environment
+call venv\Scripts\activate
+
+:: Install dependencies
+pip install -r requirements.txt
+
+echo Environment setup complete, activating environment...

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,13 @@
+# Ensure the script stops on errors
+$ErrorActionPreference = "Stop"
+
+# Create a virtual environment
+python -m venv venv
+
+# Activate the virtual environment
+& .\venv\Scripts\Activate.ps1
+
+# Install dependencies
+pip install -r requirements.txt
+
+Write-Host "Environment setup complete, activating environment..."

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Create a virtual environment
+python3 -m venv venv
+
+# Activate the virtual environment
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+echo "Environment setup complete, activating environment..."


### PR DESCRIPTION
# Problem

Project currently has no requirements.txt to set up dependencies.

# Solution

Added simple to use shell/bash/ps scripts to setup virtual python environment and install dependencies. Every time you need to add a new package to this project, simply add the name to requirements.txt to automatically install it for all contributors.

Also setup basic file structure:

main.py - main run target
lib/ - common code